### PR TITLE
FIX - Site typos and omissions

### DIFF
--- a/SITE_BASE.md
+++ b/SITE_BASE.md
@@ -1,7 +1,3 @@
----
-title: E-ARK Submission Information Package
----
-
 !TOC
 
 !INCLUDE "specification/index.md"

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+gem 'github-pages', group: :jekyll_plugins
+gem "jekyll-theme-primer", group: :jekyll_plugin

--- a/profile/E-ARK-DIP.xml
+++ b/profile/E-ARK-DIP.xml
@@ -10,12 +10,12 @@
     xsi:schemaLocation="http://www.loc.gov/METS_Profile/v2 http://www.loc.gov/standards/mets/profile_docs/mets.profile.v2-0.xsd http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.w3.org/1999/xlink http://www.loc.gov/standards/mets/xlink.xsd"
     STATUS="provisional"
     REGISTRATION="unregistered"
-    ID="DIPV2.0.0-RC">
+    ID="DIPV2.0.1">
     <URI LOCTYPE="URL" ASSIGNEDBY="local">https://earksip.dilcis.eu/profile/E-ARK-DIP.xml</URI>
-    <title>E-ARK DIP METS Profile 2.0</title>
+    <title>E-ARK DIP METS Profile</title>
     <abstract>This is the extension of the E-ARK CSIP profile for creation of a E-ARK DIP. The profile describes the Dissemination Information Package (DIP) specification and the implementation of METS for packaging OAIS conformant Information Packages. The profile is accompanied with a textuall document explaning the details of use of this profile.
         This will enable repository interoperability and assist in the management of the preservation of digital content.</abstract>
-    <date>2019-05-31T12:00:00</date>
+    <date>2019-09-04T12:00:00</date>
     <contact>
         <institution>DILCIS Board</institution>
         <address>http://dilcis.eu/</address>
@@ -77,7 +77,7 @@
             <requirement ID="DIP2" REQLEVEL="MUST" EXAMPLES="metsRootElementExample1">
                 <description>
                     <head>METS Profile</head>
-                    <p xmlns="http://www.w3.org/1999/xhtml">The value is set to "https://earksip.dilcis.eu/profile/E-ARK-DIP.xml".</p>
+                    <p xmlns="http://www.w3.org/1999/xhtml">The value is set to "https://earkdip.dilcis.eu/profile/E-ARK-DIP.xml".</p>
                     <dl xmlns="http://www.w3.org/1999/xhtml">
                         <dt>METS XPath</dt><dd>mets/@PROFILE</dd>
                         <dt>Cardinality</dt><dd>1..1</dd>

--- a/specification/index.md
+++ b/specification/index.md
@@ -25,8 +25,8 @@ The CSIP folder structure and its requirements is visualised in the figure below
 
 ![IP Folder Structure](./media/Fig2DIP.svg)
 
-- Green boxes represent folders
-- Red boxes represent files.
+- Blue boxes represent folders
+- Yellow boxes represent files.
 - Boxes with full lines represent mandatory files/folders
 - Boxes with dotted lines represent optional files/folders.
 
@@ -292,6 +292,18 @@ EAD example of \<chronlist>
  </chronlist>
 </accessrestrict>
 ```
+
+# Appendix A: E-ARK Information Package METS example
+
+!INCLUDE "appendices/examples/examples.md"
+
+# Appendix B: External Schema and Vocabularies
+
+!INCLUDE "appendices/schema/schema.md"
+
+# Appendix C: A Full List of E-ARK DIP Requirements
+
+!INCLUDE "appendices/requirements/requirements.md"
 
 ## Bibliography
 Bredenberg, Karin, Björn Skog, Anders Bo Nielsen, Kathrine Hougaard Edsen Johansen, Alex Thirifays,


### PR DESCRIPTION
- removed extraneous title from `SITE_BASE.md`;
- added include statements for appenices;
- update profile version number;
- removed version number from profile title;
- updated publication date;
- fixed path in requirement `DIP2`; and
- add Gemfile for local site production.