### PR TITLE
FIX - Specification GitHub Pages site publishing

### DIFF
--- a/create-site.sh
+++ b/create-site.sh
@@ -19,10 +19,12 @@ then
 fi
 
 bash "$SCRIPT_DIR/spec-publisher/utils/create-venv.sh"
-source "$SCRIPT_DIR/.venv/markdown/bin/activate"
+command -v markdown-pp >/dev/null 2>&1 || {
+  tmpdir=$(dirname $(mktemp -u))
+  source "$tmpdir/.venv-markdown/bin/activate"
+}
 markdown-pp SITE_BASE.md -o /tmp/site.md
 markdown-pp SITE.md -o ./docs/index.md
-deactivate
 
 cp -R specification/media docs/
 cp -R spec-publisher/res/md/figs docs/

--- a/specification/appendices/examples/examples.md
+++ b/specification/appendices/examples/examples.md
@@ -2,7 +2,7 @@
 **Example 1:** Example of a whole METS document describing an dissimination information package with no representations.
 
 ```xml
-<mets:mets OBJID="uuid-4422c185-5407-4918-83b1-7abfa77de182" LABEL="Accounting records of 2017" TYPE="OTHER" OTHERTYPE="Accounting" PROFILE="https://earksip.dilcis.eu/profile/E-ARK-DIP.xml" schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.w3.org/1999/xlink http://www.loc.gov/standards/mets/xlink.xsd https://dilcis.eu/XML/METS/CSIPExtensionMETS https://dilcis.eu/XML/METS/CSIPExtensionMETS/DILCISExtensionMETS.xsd https://dilcis.eu/XML/METS/SIPExtensionMETS https://dilcis.eu/XML/METS/SIPExtensionMETS/SIPExtensionMETS.xsd">
+<mets:mets OBJID="uuid-4422c185-5407-4918-83b1-7abfa77de182" LABEL="Accounting records of 2017" TYPE="OTHER" OTHERTYPE="Accounting" PROFILE="https://earksip.dilcis.eu/profile/E-ARK-DIP.xml" schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd http://www.w3.org/1999/xlink http://www.loc.gov/standards/mets/xlink.xsd https://dilcis.eu/XML/METS/CSIPExtensionMETS https://dilcis.eu/XML/METS/CSIPExtensionMETS/DILCISExtensionMETS.xsd https://dilcis.eu/XML/METS/SIPExtensionMETS https://dilcis.eu/XML/METS/SIPExtensionMETS/DILCISExtensionSIPMETS.xsd">
   <mets:metsHdr CREATEDATE="2018-04-24T14:37:49.602+01:00" LASTMODDATE="2018-04-24T14:37:49.602+01:00" RECORDSTATUS="NEW" OAISPACKAGETYPE="SIP">
     <mets:agent ROLE="CREATOR" TYPE="OTHER" OTHERTYPE="SOFTWARE">
       <mets:name>RODA-in</mets:name>
@@ -26,11 +26,11 @@
   <mets:fileSec ID="uuid-CA580D47-8C8B-4E91-ABD5-142EBBE15B84">
     <mets:fileGrp ID="uuid-4ACDC6F3-8A36-4A00-A85F-84A56415E86H" USE="Documentation">
       <mets:file ID="uuid-0C0049CA-6DE0-4A6D-8699-7975E4046A81" MIMETYPE="application/vnd.openxmlformats-officedocument.wordprocessingml.document" SIZE="2554366" CREATED="2012-08-15T12:08:15.432+01:00" CHECKSUM="91B7A2C0A1614AA8F3DAF11DB4A1C981F14BAA25E6A0336F715B7C513E7A1557" CHECKSUMTYPE="SHA-256" FILEFORMATNAME="Microsoft Word for Windows" FILEFORMATVERSION="2007 onwards" FORMATREGISTRY="PRONOM" FORMATREGISTRYKEY="fmt/412">
-        <mets:FLocat LOCTYPE="URL" type="simple" href="Documentation/File.docx">
+        <mets:FLocat LOCTYPE="URL" type="simple" href="documentation/File.docx">
         </mets:FLocat>
       </mets:file>
       <mets:file ID="uuid-0C0049CA-6DE0-4A6D-8699-7975E4046A82" MIMETYPE="application/vnd.openxmlformats-officedocument.wordprocessingml.document" SIZE="2554366" CREATED="2012-08-15T12:08:15.432+01:00" CHECKSUM="91B7A2C0A1614AA8F3DAF11DB4A1C981F14BAA25E6A0336F715B7C513E7A1557" CHECKSUMTYPE="SHA-256" FILEFORMATNAME="Microsoft Word for Windows" FILEFORMATVERSION="2007 onwards" FORMATREGISTRY="PRONOM" FORMATREGISTRYKEY="fmt/412">
-        <mets:FLocat LOCTYPE="URL" type="simple" href="Documentation/File2.docx">
+        <mets:FLocat LOCTYPE="URL" type="simple" href="documentation/File2.docx">
         </mets:FLocat>
       </mets:file>
     </mets:fileGrp>
@@ -42,12 +42,12 @@
     </mets:fileGrp>
     <mets:fileGrp ID="uuid-4ACDC6F3-8A36-4A00-A85F-84A56415E86G" USE="Representations/Submission/Data" CONTENTINFORMATIONTYPE="SIARDDK">
       <mets:file ID="uuid-EE23344D-4F64-40C1-8E18-75839EF661FD" MIMETYPE="application/xml" SIZE="1338744" CREATED="2018-04-24T14:37:49.617+01:00" CHECKSUM="7176A627870CFA3854468EC43C5A56F9BD8B30B50A983B8162BF56298A707667" CHECKSUMTYPE="SHA-256" ADMID="uuid-48C18DD8-2561-4315-AC39-F941CBB138B3 uuid-9124DA4D-3736-4F69-8355-EB79A22E943F" FILEFORMATNAME="Extensible Markup Language" FILEFORMATVERSION="1.0" FORMATREGISTRY="PRONOM" FORMATREGISTRYKEY="fmt/101">
-        <mets:FLocat LOCTYPE="URL" type="simple" href="representations/Submission/Data/SIARD.xml">
+        <mets:FLocat LOCTYPE="URL" type="simple" href="representations/submission/data/SIARD.xml">
         </mets:FLocat>
       </mets:file>
     </mets:fileGrp>
   </mets:fileSec>
-  <mets:structMap ID="uuid-1465D250-0A24-4714-9555-5C1211722FB8" TYPE="PHYSICAL" LABEL="CSIP StructMap">
+  <mets:structMap ID="uuid-1465D250-0A24-4714-9555-5C1211722FB8" TYPE="PHYSICAL" LABEL="CSIP">
     <mets:div ID="uuid-638362BC-65D9-4DA7-9457-5156B3965A18" LABEL="uuid-4422c185-5407-4918-83b1-7abfa77de182">
       <mets:div ID="uuid-A4E1C5B6-CD9B-43EF-8F0C-3FD3AB688F81" LABEL="Metadata" ADMID="uuid-9124DA4D-3736-4F69-8355-EB79A22E943F uuid-48C18DD8-2561-4315-AC39-F941CBB138B3" DMDID="uuid-906F4F12-BA52-4779-AE2C-178F9206111F">
       </mets:div>

--- a/specification/appendices/requirements/requirements.md
+++ b/specification/appendices/requirements/requirements.md
@@ -1,11 +1,11 @@
-| ID | Name & Location | Description & usage | Cardinality & Level |
-| -- | --------------- | ------------------- | ------------------- |
-| <a name="DIP1"></a>**DIP1** | **Package Identifier** <br/> `mets/@OBJID` | Note that the value of the `mets/@OBJID attribute` for the DIP is expected to be different from the SIP and AIP to reflect the creation of a new package. | **1..1** <br/> MUST |
-| <a name="DIP2"></a>**DIP2** | **METS Profile** <br/> `mets/@PROFILE` | The value is set to "https://earksip.dilcis.eu/profile/E-ARK-DIP.xml". | **1..1** <br/> MUST |
-| <a name="DIP3"></a>**DIP3** | **OAIS Package type information** <br/> `metsHdr[@csip:OAISPACKAGETYPE=`DIP`]` | The in CSIP added attribute `@csip:OAISPACKAGETYPE` is used with the value "DIP". <br/> **See also:** <a href="#VocabularyOAISPackageType" >OAIS Package type</a> | **1..1** <br/> MUST |
-| <a name="DIP4"></a>**DIP4** | **Status of the descriptive metadata** <br/> `dmdSec/@STATUS` | Indicates the status of the package using a fixed vocabulary. The status SHOULD in a DIP be set to "CURRENT". <br/> **See also:** <a href="#VocabularyStatus" >dmdSec status</a> | **0..1** <br/> SHOULD |
-| <a name="REF_CSIP_1"></a>**REF_CSIP_1** | **Administrative metadata** <br/>  | The DIP <amdSec> element should comply with  <br/>  <amdSec> requirements in the CSIP profile. |  <br/> SHOULD |
-| <a name="REF_CSIP_2"></a>**REF_CSIP_2** | **File section** <br/>  | The DIP <fileSec> element should comply with  <br/>  <fileSec> requirements in the CSIP profile. |  <br/> SHOULD |
-| <a name="REF_CSIP_3"></a>**REF_CSIP_3** | **Structural description of the package** <br/>  | The DIP <structMap> element should comply with  <br/>  <structMap> requirements in the CSIP profile. |  <br/> SHOULD |
-| <a name="REF_METS_1"></a>**REF_METS_1** | **structLink** <br/>  | Section not defined or used in CSIP or DIP, additional own uses may occur. |  <br/> MAY |
-| <a name="REF_METS_2"></a>**REF_METS_2** | **behaviorSec** <br/>  | Section not defined or used in CSIP or DIP, additional own uses may occur. |  <br/> MAY |
+|  ID     | Name, Location & Description | Card & Level |
+| ------- | ---------------------------- | ------------ |
+| <a name="DIP1"></a>**DIP1** | **Package Identifier** <br/> `mets/@OBJID` <br/> Note that the value of the `mets/@OBJID attribute` for the DIP is expected to be different from the SIP and AIP to reflect the creation of a new package. | **1..1** <br/> MUST |
+| <a name="DIP2"></a>**DIP2** | **METS Profile** <br/> `mets/@PROFILE` <br/> The value is set to "https://earkdip.dilcis.eu/profile/E-ARK-DIP.xml". | **1..1** <br/> MUST |
+| <a name="DIP3"></a>**DIP3** | **OAIS Package type information** <br/> `metsHdr[@csip:OAISPACKAGETYPE=`DIP`]` <br/> The in CSIP added attribute `@csip:OAISPACKAGETYPE` is used with the value "DIP". <br/> **See also:** [OAIS Package type](#VocabularyOAISPackageType) | **1..1** <br/> MUST |
+| <a name="DIP4"></a>**DIP4** | **Status of the descriptive metadata** <br/> `dmdSec/@STATUS` <br/> Indicates the status of the package using a fixed vocabulary. The status SHOULD in a DIP be set to "CURRENT". <br/> **See also:** [dmdSec status](#VocabularyStatus) | **0..1** <br/> SHOULD |
+| <a name="REF_CSIP_1"></a>**REF_CSIP_1** | **Administrative metadata** <br/>  <br/> The DIP <amdSec> element should comply with  <br/>  amdSec requirements in the CSIP profile. |  <br/> SHOULD |
+| <a name="REF_CSIP_2"></a>**REF_CSIP_2** | **File section** <br/>  <br/> The DIP fileSec element should comply with  <br/>  fileSec requirements in the CSIP profile. |  <br/> SHOULD |
+| <a name="REF_CSIP_3"></a>**REF_CSIP_3** | **Structural description of the package** <br/>  <br/> The DIP structMap element should comply with  <br/>  structMap requirements in the CSIP profile. |  <br/> SHOULD |
+| <a name="REF_METS_1"></a>**REF_METS_1** | **structLink** <br/>  <br/> Section not defined or used in CSIP or DIP, additional own uses may occur. <br/> Information regarding the structural links is found in the  <br/> METS Primer |  <br/> MAY |
+| <a name="REF_METS_2"></a>**REF_METS_2** | **behaviorSec** <br/>  <br/> Section not defined or used in CSIP or DIP, additional own uses may occur. <br/> Information regarding the behavior section is found in the  <br/> METS Primer |  <br/> MAY |

--- a/specification/appendices/schema/schema.md
+++ b/specification/appendices/schema/schema.md
@@ -1,27 +1,12 @@
-## External Schema
-
-### 
-**Location:**  <a href="http://example.com" >http://example.com</a> <br/> 
-**Context:**  <br/> 
-**Note:**   <br/> 
-No external schemas is used <br/> 
-
-## Controlled Vocabularies
-
-### OAIS Package type
-<a name="VocabularyOAISPackageType"></a>
-**Maintained By:** DILCIS Board <br/> 
-**Location:**  <a href="http://earkcsip.dilcis.eu/schema/CSIPVocabularyOAISPackageType.xml" >http://earkcsip.dilcis.eu/schema/CSIPVocabularyOAISPackageType.xml</a> <br/> 
-**Context:** Values for `@csip:OAISPACKAGETYPE` <br/> 
-**Description:**   <br/> 
-Describes the OAIS type the package belongs to in the OAIS reference model. <br/> 
 
 
-### dmdSec status
-<a name="VocabularyStatus"></a>
-**Maintained By:** DILCIS Board <br/> 
-**Location:**  <a href="http://earkcsip.dilcis.eu/schema/CSIPVocabularyStatus.xml" >http://earkcsip.dilcis.eu/schema/CSIPVocabularyStatus.xml</a> <br/> 
-**Context:** Values for `dmdSec/@STATUS` <br/> 
-**Description:**   <br/> 
-Describes the status of the descriptive metadata section (dmdSec) which is supported by the profile. <br/> 
+### E-ARK SIP METS Extension
+**Location:** [https://dilcis.eu/XML/METS/SIPExtensionMETS/DILCISExtensionSIPMETS.xsd](https://dilcis.eu/XML/METS/SIPExtensionMETS/DILCISExtensionSIPMETS.xsd)   
+
+**Context:** XML-schema for the attributes added by SIP and reused in the DIP   
+
+**Note:**     
+
+An extension schema with the added attributes for use in this profile. <br/> 
+The schema is used with a namespace prefix of sip. <br/> 
 

--- a/specification/appendices/vocabs/vocabs.md
+++ b/specification/appendices/vocabs/vocabs.md
@@ -1,0 +1,28 @@
+
+### OAIS Package type
+<a name="VocabularyOAISPackageType"></a>
+
+**Maintained By:** DILCIS Board   
+  
+**Location:** [http://earkcsip.dilcis.eu/schema/CSIPVocabularyOAISPackageType.xml](http://earkcsip.dilcis.eu/schema/CSIPVocabularyOAISPackageType.xml)   
+
+**Context:** Values for `@csip:OAISPACKAGETYPE`   
+  
+**Description:**     
+
+Describes the OAIS type the package belongs to in the OAIS reference model.  
+  
+
+### dmdSec status
+<a name="VocabularyStatus"></a>
+
+**Maintained By:** DILCIS Board   
+  
+**Location:** [http://earkcsip.dilcis.eu/schema/CSIPVocabularyStatus.xml](http://earkcsip.dilcis.eu/schema/CSIPVocabularyStatus.xml)   
+
+**Context:** Values for `dmdSec/@STATUS`   
+  
+**Description:**     
+
+Describes the status of the descriptive metadata section (dmdSec) which is supported by the profile.  
+  

--- a/specification/implementation/metadata/mets/amdsec/requirements.md
+++ b/specification/implementation/metadata/mets/amdsec/requirements.md
@@ -1,3 +1,3 @@
-| ID | Name & Location | Description & usage | Cardinality & Level |
-| -- | --------------- | ------------------- | ------------------- |
-| <a name="REF_CSIP_1"></a>**REF_CSIP_1** | **Administrative metadata** <br/>  | The DIP <amdSec> element should comply with  <br/>  <amdSec> requirements in the CSIP profile. |  <br/> SHOULD |
+|  ID     | Name, Location & Description | Card & Level |
+| ------- | ---------------------------- | ------------ |
+| <a name="REF_CSIP_1"></a>**REF_CSIP_1** | **Administrative metadata** <br/>  <br/> The DIP <amdSec> element should comply with  <br/>  amdSec requirements in the CSIP profile. |  <br/> SHOULD |

--- a/specification/implementation/metadata/mets/dmdsec/requirements.md
+++ b/specification/implementation/metadata/mets/dmdsec/requirements.md
@@ -1,3 +1,3 @@
-| ID | Name & Location | Description & usage | Cardinality & Level |
-| -- | --------------- | ------------------- | ------------------- |
-| <a name="DIP4"></a>**DIP4** | **Status of the descriptive metadata** <br/> `dmdSec/@STATUS` | Indicates the status of the package using a fixed vocabulary. The status SHOULD in a DIP be set to "CURRENT". <br/> **See also:** <a href="#VocabularyStatus" >dmdSec status</a> | **0..1** <br/> SHOULD |
+|  ID     | Name, Location & Description | Card & Level |
+| ------- | ---------------------------- | ------------ |
+| <a name="DIP4"></a>**DIP4** | **Status of the descriptive metadata** <br/> `dmdSec/@STATUS` <br/> Indicates the status of the package using a fixed vocabulary. The status SHOULD in a DIP be set to "CURRENT". <br/> **See also:** [dmdSec status](#VocabularyStatus) | **0..1** <br/> SHOULD |

--- a/specification/implementation/metadata/mets/filesec/requirements.md
+++ b/specification/implementation/metadata/mets/filesec/requirements.md
@@ -1,3 +1,3 @@
-| ID | Name & Location | Description & usage | Cardinality & Level |
-| -- | --------------- | ------------------- | ------------------- |
-| <a name="REF_CSIP_2"></a>**REF_CSIP_2** | **File section** <br/>  | The DIP <fileSec> element should comply with  <br/>  <fileSec> requirements in the CSIP profile. |  <br/> SHOULD |
+|  ID     | Name, Location & Description | Card & Level |
+| ------- | ---------------------------- | ------------ |
+| <a name="REF_CSIP_2"></a>**REF_CSIP_2** | **File section** <br/>  <br/> The DIP fileSec element should comply with  <br/>  fileSec requirements in the CSIP profile. |  <br/> SHOULD |

--- a/specification/implementation/metadata/mets/mets-root/requirements.md
+++ b/specification/implementation/metadata/mets/mets-root/requirements.md
@@ -1,4 +1,4 @@
-| ID | Name & Location | Description & usage | Cardinality & Level |
-| -- | --------------- | ------------------- | ------------------- |
-| <a name="DIP1"></a>**DIP1** | **Package Identifier** <br/> `mets/@OBJID` | Note that the value of the `mets/@OBJID attribute` for the DIP is expected to be different from the SIP and AIP to reflect the creation of a new package. | **1..1** <br/> MUST |
-| <a name="DIP2"></a>**DIP2** | **METS Profile** <br/> `mets/@PROFILE` | The value is set to "https://earksip.dilcis.eu/profile/E-ARK-DIP.xml". | **1..1** <br/> MUST |
+|  ID     | Name, Location & Description | Card & Level |
+| ------- | ---------------------------- | ------------ |
+| <a name="DIP1"></a>**DIP1** | **Package Identifier** <br/> `mets/@OBJID` <br/> Note that the value of the `mets/@OBJID attribute` for the DIP is expected to be different from the SIP and AIP to reflect the creation of a new package. | **1..1** <br/> MUST |
+| <a name="DIP2"></a>**DIP2** | **METS Profile** <br/> `mets/@PROFILE` <br/> The value is set to "https://earkdip.dilcis.eu/profile/E-ARK-DIP.xml". | **1..1** <br/> MUST |

--- a/specification/implementation/metadata/mets/metshdr/requirements.md
+++ b/specification/implementation/metadata/mets/metshdr/requirements.md
@@ -1,3 +1,3 @@
-| ID | Name & Location | Description & usage | Cardinality & Level |
-| -- | --------------- | ------------------- | ------------------- |
-| <a name="DIP3"></a>**DIP3** | **OAIS Package type information** <br/> `metsHdr[@csip:OAISPACKAGETYPE=`DIP`]` | The in CSIP added attribute `@csip:OAISPACKAGETYPE` is used with the value "DIP". <br/> **See also:** <a href="#VocabularyOAISPackageType" >OAIS Package type</a> | **1..1** <br/> MUST |
+|  ID     | Name, Location & Description | Card & Level |
+| ------- | ---------------------------- | ------------ |
+| <a name="DIP3"></a>**DIP3** | **OAIS Package type information** <br/> `metsHdr[@csip:OAISPACKAGETYPE=`DIP`]` <br/> The in CSIP added attribute `@csip:OAISPACKAGETYPE` is used with the value "DIP". <br/> **See also:** [OAIS Package type](#VocabularyOAISPackageType) | **1..1** <br/> MUST |

--- a/specification/implementation/metadata/mets/structmap/requirements.md
+++ b/specification/implementation/metadata/mets/structmap/requirements.md
@@ -1,3 +1,3 @@
-| ID | Name & Location | Description & usage | Cardinality & Level |
-| -- | --------------- | ------------------- | ------------------- |
-| <a name="REF_CSIP_3"></a>**REF_CSIP_3** | **Structural description of the package** <br/>  | The DIP <structMap> element should comply with  <br/>  <structMap> requirements in the CSIP profile. |  <br/> SHOULD |
+|  ID     | Name, Location & Description | Card & Level |
+| ------- | ---------------------------- | ------------ |
+| <a name="REF_CSIP_3"></a>**REF_CSIP_3** | **Structural description of the package** <br/>  <br/> The DIP structMap element should comply with  <br/>  structMap requirements in the CSIP profile. |  <br/> SHOULD |

--- a/specification/index.md
+++ b/specification/index.md
@@ -314,11 +314,11 @@ EAD example of \<chronlist>
 Bredenberg, Karin, Björn Skog, Anders Bo Nielsen, Kathrine Hougaard Edsen Johansen, Alex Thirifays,
 Sven Schlarb, Andrew Wilson, et al. 2018. Common Specification for Information Packages (Csip). ERCIM
 News. 2.0.0-DRAFT ed. Digital Information LifeCycle Interoperability Standard Board (DILCIS Board).
-http://earkcsip.dilcis.eu.
+[http://earkcsip.dilcis.eu/](http://earkcsip.dilcis.eu/)
 
 OAIS. 2012. Reference Model for an Open Archival Information System. CCSDS 650.0-M-2 (Magenta
-Book). CCSDS - Consultative Committee for Space Data Systems. http://public.ccsds.org/publications/
-archive/650x0b1.pdf.
+Book). CCSDS - Consultative Committee for Space Data Systems.
+[http://public.ccsds.org/publications/archive/650x0b1.pdf](http://public.ccsds.org/publications/archive/650x0b1.pdf).
 
 PREMIS. 2017. PREMIS Data Dictionary for Preservation Metadata, Version 3.0. The Library of Congress.
-https://www.loc.gov/standards/premis/v3/index.html.
+[https://www.loc.gov/standards/premis/v3/index.html](https://www.loc.gov/standards/premis/v3/index.html).

--- a/specification/index.md
+++ b/specification/index.md
@@ -292,20 +292,25 @@ EAD example of \<chronlist>
  </chronlist>
 </accessrestrict>
 ```
+# Appendices
 
-# Appendix A: E-ARK Information Package METS example
+## Appendix A: E-ARK Information Package METS example
 
 !INCLUDE "appendices/examples/examples.md"
 
-# Appendix B: External Schema and Vocabularies
+## Appendix B: External Schema
 
 !INCLUDE "appendices/schema/schema.md"
 
-# Appendix C: A Full List of E-ARK DIP Requirements
+## Appendix C: External Vocabularies
+
+!INCLUDE "appendices/vocabs/vocabs.md"
+
+## Appendix D: A Full List of E-ARK DIP Requirements
 
 !INCLUDE "appendices/requirements/requirements.md"
 
-## Bibliography
+# Bibliography
 Bredenberg, Karin, Björn Skog, Anders Bo Nielsen, Kathrine Hougaard Edsen Johansen, Alex Thirifays,
 Sven Schlarb, Andrew Wilson, et al. 2018. Common Specification for Information Packages (Csip). ERCIM
 News. 2.0.0-DRAFT ed. Digital Information LifeCycle Interoperability Standard Board (DILCIS Board).

--- a/specification/postface/revisions.md
+++ b/specification/postface/revisions.md
@@ -3,7 +3,8 @@
 
 | Revision No. | Date       | Authors(s)                       | Organisation | Description                                                           |
 |--------------|------------|----------------------------------|--------------|----------------------------|
-| 1.0          | 20.12.2018 | Phillip Tømmerholt <br/>Anders Bo Nielsen | DNA | Review version             |
-| 1.0.1        | 20.03.2019 | Phillip Tømmerholt <br/>Anders Bo Nielsen | DNA | Corrected typos            |
-| 1.0.2        | 26.04.2019 | Phillip Tømmerholt <br/>Anders Bo Nielsen | DNA | Corrected typos            |
-| 1.1.0        | 27.05.2019 | Phillip Tømmerholt <br/>Anders Bo Nielsen | DNA | Align with CSIP            |
+| 2.0-DRAFT    | 20.12.2018 | Phillip Tømmerholt <br/>Anders Bo Nielsen | DNA | Review version             |
+| 2.0-RC       | 20.03.2019 | Phillip Tømmerholt <br/>Anders Bo Nielsen | DNA | Corrected typos            |
+| 2.0-RC2      | 26.04.2019 | Phillip Tømmerholt <br/>Anders Bo Nielsen | DNA | Corrected typos            |
+| 2.0.0        | 27.05.2019 | Phillip Tømmerholt <br/>Anders Bo Nielsen | DNA | Align with CSIP            |
+| 2.0.1        | 09.09.2019 | Carl Wilson <br/>Karin Bredenberg         | OPF | Layout and PDF Generation  |

--- a/specification/postface/revisions.md
+++ b/specification/postface/revisions.md
@@ -7,4 +7,4 @@
 | 2.0-RC       | 20.03.2019 | Phillip Tømmerholt <br/>Anders Bo Nielsen | DNA | Corrected typos            |
 | 2.0-RC2      | 26.04.2019 | Phillip Tømmerholt <br/>Anders Bo Nielsen | DNA | Corrected typos            |
 | 2.0.0        | 27.05.2019 | Phillip Tømmerholt <br/>Anders Bo Nielsen | DNA | Align with CSIP            |
-| 2.0.1        | 09.09.2019 | Carl Wilson <br/>Karin Bredenberg         | OPF | Layout and PDF Generation  |
+| 2.0.1        | 09.09.2019 | Carl Wilson <br/>Karin Bredenberg         | OPF <br/>SNA| Layout and PDF Generation  |


### PR DESCRIPTION
- using latest `spec-publisher` build with Appendices fix;
- changed Appendix heading levels in `specification/index.md`;
- changed Bibliography heading level;
- reformatted revision history; and
- using temp based `markdownPP` virtualenv.